### PR TITLE
Add "Reveal in Finder" button to locate plist files

### DIFF
--- a/defaults edit/DefaultsEdit/Model/DefaultsDomain.swift
+++ b/defaults edit/DefaultsEdit/Model/DefaultsDomain.swift
@@ -125,6 +125,69 @@ class DefaultsDomain: NSObject {
         }
     }
 
+    var preferenceFileURL: URL? {
+        guard let domainName else {
+            return nil
+        }
+        
+        let preferenceFileName: String
+        switch impl {
+        case .bundle, .domainName:
+            preferenceFileName = "\(domainName).plist"
+        case .globalDomain:
+            preferenceFileName = ".GlobalPreferences.plist"
+        }
+        
+        let fileManager = FileManager.default
+        let homeDir = fileManager.homeDirectoryForCurrentUser
+        
+        for preferencesDir in [
+            homeDir.appendingPathComponent("Library/Preferences"),
+            URL(fileURLWithPath: "/Library/Preferences"),
+        ] {
+            let preferenceFile = preferencesDir.appendingPathComponent(preferenceFileName)
+            guard fileManager.fileExists(atPath: preferenceFile.path) else {
+                continue
+            }
+            
+            return preferenceFile
+            
+        }
+        
+        for preferencesDir in [
+            homeDir.appendingPathComponent("Library/Preferences/ByHost", isDirectory: true),
+        ] {
+            guard
+                let files = try? fileManager.contentsOfDirectory(at: preferencesDir, includingPropertiesForKeys: nil),
+                let preferenceFile = files.first(where: {
+                    $0.lastPathComponent.hasPrefix(domainName) && $0.lastPathComponent.hasSuffix(".plist")
+                })
+            else {
+                continue
+            }
+            
+            return preferenceFile
+        }
+        
+        for libraryDir in fileManager.urls(for: .libraryDirectory, in: .allDomainsMask) {
+            let preferenceFile = libraryDir
+                .appendingPathComponent("Containers", isDirectory: true)
+                .appendingPathComponent(domainName, isDirectory: true)
+                .appendingPathComponent("Data/Library/Preferences", isDirectory: true)
+                .appendingPathComponent(preferenceFileName, isDirectory: false)
+            guard
+                let reachable = try? preferenceFile.checkResourceIsReachable(),
+                reachable
+            else {
+                continue
+            }
+            
+            return preferenceFile
+        }
+        
+        return nil
+    }
+
 }
 
 extension Bundle {

--- a/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
+++ b/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
@@ -20,7 +20,7 @@
                                     <customView horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ppP-56-oxe" userLabel="Title">
                                         <rect key="frame" x="0.0" y="522" width="860" height="62"/>
                                         <subviews>
-                                            <textField focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qik-PV-DGZ">
+                                            <textField horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qik-PV-DGZ">
                                                 <rect key="frame" x="-2" y="32" width="129" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="xKE-ce-c18"/>
@@ -34,7 +34,7 @@
                                                     <binding destination="XfG-lQ-9wD" name="value" keyPath="representedObject.localizedName" id="EjM-qr-MzE"/>
                                                 </connections>
                                             </textField>
-                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EWY-dH-Wa0">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EWY-dH-Wa0">
                                                 <rect key="frame" x="-2" y="0.0" width="180" height="30"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="30" id="qgU-tf-vrK"/>
@@ -93,7 +93,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="C1S-HP-4HT" userLabel="View Settings">
                                         <rect key="frame" x="0.0" y="459" width="860" height="63"/>
                                         <subviews>
-                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5MX-bq-My6">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5MX-bq-My6">
                                                 <rect key="frame" x="-2" y="40" width="50" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="W1z-lW-zsB"/>
@@ -104,7 +104,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WoP-6k-gog">
+                                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WoP-6k-gog">
                                                 <rect key="frame" x="54" y="42" width="806" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="21" id="x9J-3Q-fA2"/>
@@ -141,7 +141,7 @@
                                                     </binding>
                                                 </connections>
                                             </segmentedControl>
-                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yaJ-CX-UyB">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yaJ-CX-UyB">
                                                 <rect key="frame" x="-2" y="14" width="90" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="View defaults:" id="vxz-f6-7Uh">
                                                     <font key="font" metaFont="smallSystem" size="13"/>

--- a/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
+++ b/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="XfG-lQ-9wD">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="XfG-lQ-9wD">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,14 +11,14 @@
             <objects>
                 <viewController id="XfG-lQ-9wD" customClass="ViewController" customModule="defaults_edit" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="m2S-Jp-Qdl">
-                        <rect key="frame" x="0.0" y="0.0" width="900" height="612"/>
+                        <rect key="frame" x="0.0" y="0.0" width="900" height="614"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <stackView distribution="fill" orientation="vertical" alignment="centerX" spacing="0.0" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="roj-9d-5U6">
-                                <rect key="frame" x="20" y="10" width="860" height="582"/>
+                                <rect key="frame" x="20" y="10" width="860" height="584"/>
                                 <subviews>
                                     <customView horizontalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="ppP-56-oxe" userLabel="Title">
-                                        <rect key="frame" x="0.0" y="520" width="860" height="62"/>
+                                        <rect key="frame" x="0.0" y="522" width="860" height="62"/>
                                         <subviews>
                                             <textField focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qik-PV-DGZ">
                                                 <rect key="frame" x="-2" y="32" width="129" height="30"/>
@@ -48,8 +48,18 @@
                                                     <binding destination="XfG-lQ-9wD" name="value" keyPath="representedObject.domainName" id="dk4-RH-iwP"/>
                                                 </connections>
                                             </textField>
+                                            <button toolTip="Reveal .plist in Finder" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fmr-8H-3vT" userLabel="Reveal .plist in Finder">
+                                                <rect key="frame" x="183" y="9" width="27" height="23"/>
+                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRevealFreestandingTemplate" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cel-Fmr-8H-3vT">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="smallSystem" size="13"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="revealPlistInFinder:" target="XfG-lQ-9wD" id="act-Fmr-8H-3vT"/>
+                                                </connections>
+                                            </button>
                                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lqS-ss-mU0">
-                                                <rect key="frame" x="183" y="9" width="100" height="23"/>
+                                                <rect key="frame" x="216" y="9" width="100" height="23"/>
                                                 <buttonCell key="cell" type="roundTextured" title="Relaunch App" bezelStyle="texturedRounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Bgn-Sf-Soj">
                                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                     <font key="font" metaFont="smallSystem" size="13"/>
@@ -63,41 +73,28 @@
                                                     </binding>
                                                 </connections>
                                             </button>
-                                            <button toolTip="Reveal plist file in Finder" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fmr-8H-3vT">
-                                                <rect key="frame" x="287" y="9" width="23" height="23"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="23" id="wid-Fmr-8H-3vT"/>
-                                                </constraints>
-                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRevealFreestandingTemplate" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cel-Fmr-8H-3vT">
-                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                    <font key="font" metaFont="smallSystem" size="13"/>
-                                                </buttonCell>
-                                                <connections>
-                                                    <action selector="revealPlistInFinder:" target="XfG-lQ-9wD" id="act-Fmr-8H-3vT"/>
-                                                </connections>
-                                            </button>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="lqS-ss-mU0" firstAttribute="firstBaseline" secondItem="EWY-dH-Wa0" secondAttribute="firstBaseline" id="877-fY-klj"/>
+                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="firstBaseline" secondItem="EWY-dH-Wa0" secondAttribute="firstBaseline" id="8Dy-ja-QXK"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qik-PV-DGZ" secondAttribute="trailing" priority="750" id="BW2-1x-LYB"/>
                                             <constraint firstItem="EWY-dH-Wa0" firstAttribute="leading" secondItem="qik-PV-DGZ" secondAttribute="leading" id="HsT-bg-qFU"/>
                                             <constraint firstItem="qik-PV-DGZ" firstAttribute="top" secondItem="ppP-56-oxe" secondAttribute="top" id="IP5-hd-ldx"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EWY-dH-Wa0" secondAttribute="trailing" id="O2w-3e-mDv"/>
-                                            <constraint firstItem="lqS-ss-mU0" firstAttribute="leading" secondItem="EWY-dH-Wa0" secondAttribute="trailing" constant="8" symbolic="YES" id="VVq-R7-vgw"/>
+                                            <constraint firstItem="lqS-ss-mU0" firstAttribute="leading" secondItem="Fmr-8H-3vT" secondAttribute="trailing" constant="8" symbolic="YES" id="VVq-R7-vgw"/>
                                             <constraint firstAttribute="bottom" secondItem="EWY-dH-Wa0" secondAttribute="bottom" id="Ybk-gt-Hi9"/>
+                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="leading" secondItem="EWY-dH-Wa0" secondAttribute="trailing" constant="8" symbolic="YES" id="con-Fmr-8H-3vT-lead"/>
+                                            <constraint firstItem="lqS-ss-mU0" firstAttribute="firstBaseline" secondItem="Fmr-8H-3vT" secondAttribute="firstBaseline" id="g6m-Kr-kfR"/>
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="400" id="pcZ-bm-wD5"/>
                                             <constraint firstItem="EWY-dH-Wa0" firstAttribute="firstBaseline" secondItem="qik-PV-DGZ" secondAttribute="baseline" constant="20" id="qrs-aN-kWp"/>
                                             <constraint firstItem="qik-PV-DGZ" firstAttribute="leading" secondItem="ppP-56-oxe" secondAttribute="leading" id="u95-dZ-6CD"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="lqS-ss-mU0" secondAttribute="trailing" constant="20" symbolic="YES" id="z1c-ON-h5I"/>
-                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="leading" secondItem="lqS-ss-mU0" secondAttribute="trailing" constant="8" id="con-Fmr-8H-3vT-lead"/>
-                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="centerY" secondItem="lqS-ss-mU0" secondAttribute="centerY" id="con-Fmr-8H-3vT-centerY"/>
                                         </constraints>
                                     </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="C1S-HP-4HT" userLabel="View Settings">
-                                        <rect key="frame" x="0.0" y="459" width="860" height="61"/>
+                                        <rect key="frame" x="0.0" y="459" width="860" height="63"/>
                                         <subviews>
                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5MX-bq-My6">
-                                                <rect key="frame" x="-2" y="38" width="50" height="20"/>
+                                                <rect key="frame" x="-2" y="40" width="50" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="W1z-lW-zsB"/>
                                                 </constraints>
@@ -108,7 +105,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WoP-6k-gog">
-                                                <rect key="frame" x="54" y="40" width="806" height="21"/>
+                                                <rect key="frame" x="54" y="42" width="806" height="21"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="21" id="x9J-3Q-fA2"/>
                                                 </constraints>
@@ -128,7 +125,7 @@
                                                 </connections>
                                             </textField>
                                             <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZuN-ML-MAy">
-                                                <rect key="frame" x="92" y="9" width="230" height="24"/>
+                                                <rect key="frame" x="94" y="10" width="242" height="24"/>
                                                 <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Uau-pE-OKE">
                                                     <font key="font" metaFont="smallSystem" size="13"/>
                                                     <segments>
@@ -145,7 +142,7 @@
                                                 </connections>
                                             </segmentedControl>
                                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yaJ-CX-UyB">
-                                                <rect key="frame" x="-2" y="13" width="90" height="16"/>
+                                                <rect key="frame" x="-2" y="14" width="90" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" title="View defaults:" id="vxz-f6-7Uh">
                                                     <font key="font" metaFont="smallSystem" size="13"/>
                                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -201,6 +198,7 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="filterTextField" destination="WoP-6k-gog" id="gPf-F2-fmN"/>
                         <outlet property="viewTypeSC" destination="ZuN-ML-MAy" id="nf9-a7-lWn"/>
                         <segue destination="5uI-u9-9NE" kind="sheet" identifier="ShowOpenSheet" id="kdr-FA-b6T"/>
                     </connections>
@@ -227,6 +225,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="NSRevealFreestandingTemplate" width="14" height="14"/>
+        <image name="NSRevealFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>

--- a/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
+++ b/defaults edit/DefaultsEdit/UI/Editor/Editor.storyboard
@@ -63,6 +63,19 @@
                                                     </binding>
                                                 </connections>
                                             </button>
+                                            <button toolTip="Reveal plist file in Finder" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fmr-8H-3vT">
+                                                <rect key="frame" x="287" y="9" width="23" height="23"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="23" id="wid-Fmr-8H-3vT"/>
+                                                </constraints>
+                                                <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRevealFreestandingTemplate" imagePosition="only" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="cel-Fmr-8H-3vT">
+                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <font key="font" metaFont="smallSystem" size="13"/>
+                                                </buttonCell>
+                                                <connections>
+                                                    <action selector="revealPlistInFinder:" target="XfG-lQ-9wD" id="act-Fmr-8H-3vT"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="lqS-ss-mU0" firstAttribute="firstBaseline" secondItem="EWY-dH-Wa0" secondAttribute="firstBaseline" id="877-fY-klj"/>
@@ -76,6 +89,8 @@
                                             <constraint firstItem="EWY-dH-Wa0" firstAttribute="firstBaseline" secondItem="qik-PV-DGZ" secondAttribute="baseline" constant="20" id="qrs-aN-kWp"/>
                                             <constraint firstItem="qik-PV-DGZ" firstAttribute="leading" secondItem="ppP-56-oxe" secondAttribute="leading" id="u95-dZ-6CD"/>
                                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="lqS-ss-mU0" secondAttribute="trailing" constant="20" symbolic="YES" id="z1c-ON-h5I"/>
+                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="leading" secondItem="lqS-ss-mU0" secondAttribute="trailing" constant="8" id="con-Fmr-8H-3vT-lead"/>
+                                            <constraint firstItem="Fmr-8H-3vT" firstAttribute="centerY" secondItem="lqS-ss-mU0" secondAttribute="centerY" id="con-Fmr-8H-3vT-centerY"/>
                                         </constraints>
                                     </customView>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="C1S-HP-4HT" userLabel="View Settings">
@@ -211,4 +226,7 @@
             <point key="canvasLocation" x="-271" y="1225"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="NSRevealFreestandingTemplate" width="14" height="14"/>
+    </resources>
 </document>

--- a/defaults edit/DefaultsEdit/UI/Editor/ViewController.swift
+++ b/defaults edit/DefaultsEdit/UI/Editor/ViewController.swift
@@ -67,6 +67,19 @@ struct GlobalDefaults: DefaultsModifier {
 /// Controls a defaults domain editor view.
 class ViewController: NSViewController {
     
+    // MARK: - Constants
+    
+    /// Standard paths where macOS stores preferences
+    private struct PreferencesPaths {
+        static let userPreferencesSubpath = "Library/Preferences"
+        static let byHostSubpath = "Library/Preferences/ByHost"
+        static let managedPreferencesSubpath = "Library/Managed Preferences"
+        static let systemPreferences = "/Library/Preferences"
+        static let systemManagedPreferences = "/Library/Managed Preferences"
+        static let containersSubpath = "Library/Containers"
+        static let containerDataPreferencesSubpath = "Data/Library/Preferences"
+    }
+    
     /// The defaults domain represented by this editor view.
     private var representedDomain: DefaultsDomain! {
         return representedObject as? DefaultsDomain
@@ -235,6 +248,84 @@ class ViewController: NSViewController {
             return
         }
         NSWorkspace.shared.openApplication(at: url, configuration: NSWorkspace.OpenConfiguration())
+    }
+    
+    /// Searches for a plist file in all standard preferences directories.
+    private func findPlistFile(for domainName: String) -> URL? {
+        let fileName: String
+        if domainName == UserDefaults.globalDomain {
+            fileName = ".GlobalPreferences.plist"
+        } else {
+            fileName = "\(domainName).plist"
+        }
+        
+        let fileManager = FileManager.default
+        let homeDir = fileManager.homeDirectoryForCurrentUser
+        
+        // All possible preference directories to search
+        let searchPaths: [URL] = [
+            homeDir.appendingPathComponent(PreferencesPaths.userPreferencesSubpath),
+            homeDir.appendingPathComponent(PreferencesPaths.byHostSubpath),
+            homeDir.appendingPathComponent(PreferencesPaths.managedPreferencesSubpath),
+            URL(fileURLWithPath: PreferencesPaths.systemPreferences),
+            URL(fileURLWithPath: PreferencesPaths.systemManagedPreferences),
+            homeDir.appendingPathComponent(PreferencesPaths.containersSubpath)
+        ]
+        
+        for searchPath in searchPaths {
+            // Try exact file name first
+            let exactPath = searchPath.appendingPathComponent(fileName)
+            if fileManager.fileExists(atPath: exactPath.path) {
+                return exactPath
+            }
+            
+            // For ByHost and Containers, search with prefix pattern
+            if fileManager.fileExists(atPath: searchPath.path),
+               let files = try? fileManager.contentsOfDirectory(atPath: searchPath.path) {
+                // Look for files matching the domain name pattern
+                if let matchingFile = files.first(where: { file in
+                    // Match exact name or with UUID suffix (ByHost pattern)
+                    return file == fileName || 
+                           (file.hasPrefix(domainName) && file.hasSuffix(".plist"))
+                }) {
+                    return searchPath.appendingPathComponent(matchingFile)
+                }
+                
+                // Special handling for Containers directory - search recursively
+                if searchPath.lastPathComponent == "Containers" {
+                    for containerDir in files {
+                        let containerPrefs = searchPath
+                            .appendingPathComponent(containerDir)
+                            .appendingPathComponent(PreferencesPaths.containerDataPreferencesSubpath)
+                        let containerFile = containerPrefs.appendingPathComponent(fileName)
+                        if fileManager.fileExists(atPath: containerFile.path) {
+                            return containerFile
+                        }
+                    }
+                }
+            }
+        }
+        
+        return nil
+    }
+    
+    /// Opens Finder to show the folder containing the plist file for the current domain.
+    @IBAction func revealPlistInFinder(_ sender: Any?) {
+        guard let domainName = representedDomain.domainName else {
+            return
+        }
+        
+        // Search for the plist file in all standard locations
+        if let plistPath = findPlistFile(for: domainName) {
+            let parentDir = plistPath.deletingLastPathComponent()
+            NSWorkspace.shared.selectFile(plistPath.path, inFileViewerRootedAtPath: parentDir.path)
+            return
+        }
+        
+        // If file doesn't exist yet, open the default user preferences directory
+        let defaultPrefsDir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(PreferencesPaths.userPreferencesSubpath)
+        NSWorkspace.shared.selectFile(nil, inFileViewerRootedAtPath: defaultPrefsDir.path)
     }
     
     /// Shows the Open Defaults Domain sheet on the view's window, and closes

--- a/defaults edit/DefaultsEdit/UI/Editor/ViewController.swift
+++ b/defaults edit/DefaultsEdit/UI/Editor/ViewController.swift
@@ -246,7 +246,7 @@ class ViewController: NSViewController {
             return
         }
         
-        guard NSWorkspace.shared.selectFile(plistURL.path, inFileViewerRootedAtPath: NSHomeDirectory()) else {
+        guard NSWorkspace.shared.selectFile(plistURL.path, inFileViewerRootedAtPath: plistURL.deletingLastPathComponent().path) else {
             let alert = NSAlert()
             alert.messageText = "Couldn't reveal in Finder."
             alert.informativeText = "Path: \(plistURL.path)"


### PR DESCRIPTION
## What's new

Added a new button next to the "Relaunch App" option that allows users to quickly find and reveal the actual plist file for the currently viewed defaults domain in Finder.

<img src="https://github.com/user-attachments/assets/b2216cf7-ab07-4f5f-a525-c6fd461a7284" width=100%>

## Features

- **Quick access**: Single click to open Finder and highlight the plist file
- **Smart search**: Automatically searches all standard macOS preferences locations:
  - User preferences (`~/Library/Preferences`)
  - Per-host preferences (`~/Library/Preferences/ByHost`)
  - Managed preferences (both user and system)
  - Sandboxed app containers
  - System preferences (`/Library/Preferences`)
- **Always works**: If the plist file doesn't exist yet (new domain), opens the default preferences folder
- **Clear UI**: Uses the standard macOS "reveal" icon with a helpful tooltip

## Why this is useful

When working with defaults domains, it's often helpful to:
- Inspect the raw plist file structure
- Backup preference files
- Troubleshoot issues by comparing file timestamps
- Share preference files with others
- Understand where macOS actually stores the settings

Previously, users had to manually navigate to various Library folders and search for the correct plist file, which could be time-consuming and confusing given the multiple possible locations.

## Technical notes

- Implemented using standard Finder integration APIs
- Uses centralized path constants to avoid code duplication
- Follows macOS conventions for preference file discovery